### PR TITLE
Show 'passed' label for dates that have already occurred

### DIFF
--- a/locales/de_DE.json
+++ b/locales/de_DE.json
@@ -5,5 +5,6 @@
   "actions.daysuntil.dateformat.title": "Datumsformat anzeigen",
   "actions.daysuntil.dateformat.subtitle": "Zwischen JJJJ/MM/TT und MM/TT/JJJJ wechseln",
   "actions.daysuntil.toplabel.font": "14",
-  "actions.daysuntil.days_label": "Tage"
+  "actions.daysuntil.days_label": "Tage",
+  "actions.daysuntil.passed_label": "vergangen"
 }

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -3,6 +3,7 @@
   "actions.daysuntil.name": "Days Until",
   "actions.daysuntil.toplabel.font": "14",
   "actions.daysuntil.days_label": "days",
+  "actions.daysuntil.passed_label": "passed",
   "actions.daysuntil.date.title": "Target Date (yyyy/mm/dd)",
   "actions.daysuntil.dateformat.title": "Date Format",
   "actions.daysuntil.dateformat.subtitle": "Switch between yyyy/mm/dd and mm/dd/yyyy"

--- a/locales/es_ES.json
+++ b/locales/es_ES.json
@@ -5,5 +5,6 @@
   "actions.daysuntil.dateformat.title": "Formato de fecha",
   "actions.daysuntil.dateformat.subtitle": "Cambiar entre aaaa/mm/dd y mm/dd/aaaa",
   "actions.daysuntil.toplabel.font": "14",
-  "actions.daysuntil.days_label": "días"
+  "actions.daysuntil.days_label": "días",
+  "actions.daysuntil.passed_label": "pasado"
 }

--- a/locales/fr_FR.json
+++ b/locales/fr_FR.json
@@ -5,5 +5,6 @@
   "actions.daysuntil.dateformat.title": "Format de date",
   "actions.daysuntil.dateformat.subtitle": "Basculer entre aaaa/mm/jj et mm/jj/aaaa",
   "actions.daysuntil.toplabel.font": "12",
-  "actions.daysuntil.days_label": "jours"
+  "actions.daysuntil.days_label": "jours",
+  "actions.daysuntil.passed_label": "passé"
 }

--- a/locales/ru_RU.json
+++ b/locales/ru_RU.json
@@ -5,5 +5,6 @@
   "actions.daysuntil.dateformat.title": "Формат даты",
   "actions.daysuntil.dateformat.subtitle": "Переключение между гггг/мм/дд и мм/дд/гггг",
   "actions.daysuntil.toplabel.font": "14",
-  "actions.daysuntil.days_label": "дней"
+  "actions.daysuntil.days_label": "дней",
+  "actions.daysuntil.passed_label": "прошло"
 }

--- a/main.py
+++ b/main.py
@@ -97,7 +97,10 @@ class DaysUntilAction(ActionBase):
         days = self.calculate_days_until(date_str) if date_str else None
 
         if date_str and days is not None:
-            label = f"\n{days} {lm.get('actions.daysuntil.days_label', 'days')}"
+            if days < 0:
+                label = f"\n{lm.get('actions.daysuntil.passed_label', 'passed')}"
+            else:
+                label = f"\n{days} {lm.get('actions.daysuntil.days_label', 'days')}"
             font_size = 15
         else:
             label = "\n--"
@@ -111,7 +114,7 @@ class DaysUntilAction(ActionBase):
             target_date = datetime.datetime.strptime(date_str, "%Y/%m/%d").date()
             today = datetime.date.today()
             delta = (target_date - today).days
-            return max(delta, 0)
+            return delta
         except Exception as e:
             log.warning(f"Failed to parse date '{date_str}': {e}")
             return None


### PR DESCRIPTION
Show "passed" label for dates that have already occurred. Past dates previously showed 0 days, making them indistinguishable from today. Now displays a localized "passed" string when the target date is in the past. Added translations for all 5 supported locales (en, de, es, fr, ru).