### PR TITLE
Refresh countdown label on each tick

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,6 +57,9 @@ class DaysUntilAction(ActionBase):
     def on_ready(self):
         self.update_labels()
 
+    def on_tick(self):
+        self.update_labels()
+
     def update_labels(self):
         settings = self.get_settings()
         date_str = settings.get("target_date", "").strip()


### PR DESCRIPTION
Refresh countdown label on each tick. The day count was only updated on startup and when the user changed settings, meaning the display would go stale overnight. Adding on_tick ensures the count decrements automatically without requiring a restart.