### PR TITLE
Capitalize passed_label in all locales

### DIFF
--- a/locales/de_DE.json
+++ b/locales/de_DE.json
@@ -6,5 +6,5 @@
   "actions.daysuntil.dateformat.subtitle": "Zwischen JJJJ/MM/TT und MM/TT/JJJJ wechseln",
   "actions.daysuntil.toplabel.font": "14",
   "actions.daysuntil.days_label": "Tage",
-  "actions.daysuntil.passed_label": "vergangen"
+  "actions.daysuntil.passed_label": "Vergangen"
 }

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -3,7 +3,7 @@
   "actions.daysuntil.name": "Days Until",
   "actions.daysuntil.toplabel.font": "14",
   "actions.daysuntil.days_label": "days",
-  "actions.daysuntil.passed_label": "passed",
+  "actions.daysuntil.passed_label": "Passed",
   "actions.daysuntil.date.title": "Target Date (yyyy/mm/dd)",
   "actions.daysuntil.dateformat.title": "Date Format",
   "actions.daysuntil.dateformat.subtitle": "Switch between yyyy/mm/dd and mm/dd/yyyy"

--- a/locales/es_ES.json
+++ b/locales/es_ES.json
@@ -6,5 +6,5 @@
   "actions.daysuntil.dateformat.subtitle": "Cambiar entre aaaa/mm/dd y mm/dd/aaaa",
   "actions.daysuntil.toplabel.font": "14",
   "actions.daysuntil.days_label": "días",
-  "actions.daysuntil.passed_label": "pasado"
+  "actions.daysuntil.passed_label": "Pasado"
 }

--- a/locales/fr_FR.json
+++ b/locales/fr_FR.json
@@ -6,5 +6,5 @@
   "actions.daysuntil.dateformat.subtitle": "Basculer entre aaaa/mm/jj et mm/jj/aaaa",
   "actions.daysuntil.toplabel.font": "12",
   "actions.daysuntil.days_label": "jours",
-  "actions.daysuntil.passed_label": "passé"
+  "actions.daysuntil.passed_label": "Passé"
 }

--- a/locales/ru_RU.json
+++ b/locales/ru_RU.json
@@ -6,5 +6,5 @@
   "actions.daysuntil.dateformat.subtitle": "Переключение между гггг/мм/дд и мм/дд/гггг",
   "actions.daysuntil.toplabel.font": "14",
   "actions.daysuntil.days_label": "дней",
-  "actions.daysuntil.passed_label": "прошло"
+  "actions.daysuntil.passed_label": "Прошло"
 }


### PR DESCRIPTION
Capitalize the "Passed" label across all locales. Previously displayed in lowercase, which was inconsistent with the rest of the UI.