### PR TITLE
Fix date validation style

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,9 @@ from gi.repository import Gtk, Adw
 
 import datetime
 
+_error_css = Gtk.CssProvider()
+_error_css.load_from_data(b".soft-error { background-color: rgba(200, 50, 50, 0.35); }")
+
 class DaysUntilAction(ActionBase):
     HAS_CONFIGURATION = True  # Show config after adding
 
@@ -34,8 +37,8 @@ class DaysUntilAction(ActionBase):
             try:
                 datetime.datetime.strptime(target_date_str, "%Y/%m/%d")
             except ValueError:
-                self.date_entry_row.set_opacity(0.4)
-                self.date_entry_row.add_css_class("error")
+                self.date_entry_row.get_style_context().add_provider(_error_css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+                self.date_entry_row.add_css_class("soft-error")
         self.date_entry_row.connect("notify::text", self.on_date_changed)
 
         self.date_format_switch = Adw.SwitchRow(
@@ -53,15 +56,13 @@ class DaysUntilAction(ActionBase):
         if new_date:
             try:
                 datetime.datetime.strptime(new_date, "%Y/%m/%d")
-                entry_row.set_opacity(1.0)
-                entry_row.remove_css_class("error")
+                entry_row.remove_css_class("soft-error")
             except ValueError:
-                entry_row.set_opacity(0.4)
-                entry_row.add_css_class("error")
+                entry_row.get_style_context().add_provider(_error_css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+                entry_row.add_css_class("soft-error")
                 return
         else:
-            entry_row.set_opacity(1.0)
-            entry_row.remove_css_class("error")
+            entry_row.remove_css_class("soft-error")
         settings["target_date"] = new_date
         self.set_settings(settings)
         self.update_labels()

--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ class DaysUntilAction(ActionBase):
             try:
                 datetime.datetime.strptime(target_date_str, "%Y/%m/%d")
             except ValueError:
-                self.date_entry_row.add_css_class("dim-label")
+                self.date_entry_row.set_opacity(0.4)
         self.date_entry_row.connect("notify::text", self.on_date_changed)
 
         self.date_format_switch = Adw.SwitchRow(
@@ -52,12 +52,12 @@ class DaysUntilAction(ActionBase):
         if new_date:
             try:
                 datetime.datetime.strptime(new_date, "%Y/%m/%d")
-                entry_row.remove_css_class("dim-label")
+                entry_row.set_opacity(1.0)
             except ValueError:
-                entry_row.add_css_class("dim-label")
+                entry_row.set_opacity(0.4)
                 return
         else:
-            entry_row.remove_css_class("dim-label")
+            entry_row.set_opacity(1.0)
         settings["target_date"] = new_date
         self.set_settings(settings)
         self.update_labels()

--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ class DaysUntilAction(ActionBase):
             try:
                 datetime.datetime.strptime(target_date_str, "%Y/%m/%d")
             except ValueError:
-                self.date_entry_row.add_css_class("error")
+                self.date_entry_row.add_css_class("dim-label")
         self.date_entry_row.connect("notify::text", self.on_date_changed)
 
         self.date_format_switch = Adw.SwitchRow(
@@ -52,12 +52,12 @@ class DaysUntilAction(ActionBase):
         if new_date:
             try:
                 datetime.datetime.strptime(new_date, "%Y/%m/%d")
-                entry_row.remove_css_class("error")
+                entry_row.remove_css_class("dim-label")
             except ValueError:
-                entry_row.add_css_class("error")
+                entry_row.add_css_class("dim-label")
                 return
         else:
-            entry_row.remove_css_class("error")
+            entry_row.remove_css_class("dim-label")
         settings["target_date"] = new_date
         self.set_settings(settings)
         self.update_labels()

--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ class DaysUntilAction(ActionBase):
                 datetime.datetime.strptime(target_date_str, "%Y/%m/%d")
             except ValueError:
                 self.date_entry_row.set_opacity(0.4)
+                self.date_entry_row.add_css_class("error")
         self.date_entry_row.connect("notify::text", self.on_date_changed)
 
         self.date_format_switch = Adw.SwitchRow(
@@ -53,11 +54,14 @@ class DaysUntilAction(ActionBase):
             try:
                 datetime.datetime.strptime(new_date, "%Y/%m/%d")
                 entry_row.set_opacity(1.0)
+                entry_row.remove_css_class("error")
             except ValueError:
                 entry_row.set_opacity(0.4)
+                entry_row.add_css_class("error")
                 return
         else:
             entry_row.set_opacity(1.0)
+            entry_row.remove_css_class("error")
         settings["target_date"] = new_date
         self.set_settings(settings)
         self.update_labels()


### PR DESCRIPTION
Replace set_opacity with a custom CSS provider that targets only the background color, keeping text at full opacity. Invalid date input now shows a muted red background (rgba(200, 50, 50, 0.35)) without dimming the text.